### PR TITLE
Fix instructions to use with webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All you have to do is add an alias for `react` and `react-dom`:
 ```js
 {
 	// ...
-	modules: {
+	resolve: {
 		alias: {
 			'react': 'preact-compat',
 			'react-dom': 'preact-compat'


### PR DESCRIPTION
In webpack, we need to use `resolve.alias`, instead `module.alias` =)