### PR TITLE
Do not autobind constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ let createClass = obj => {
 let bindAll = ctx => {
 	for (let i in ctx) {
 		let v = ctx[i];
-		if (typeof v==='function' && !v.__bound) {
+		if (i!=='constructor' && typeof v==='function' && !v.__bound) {
 			(ctx[i] = v.bind(ctx)).__bound = true;
 		}
 	}


### PR DESCRIPTION
Current implementation of `createClass` autobinds every method including `constructor`. It leads to the bug where child component is being unmounted/mounted completely instead of updating.
The bug occurs in the following line: https://github.com/developit/preact/blob/master/src/vdom/component.js#L108
`inst.constructor` is never equal to `childComponent` because of autobinding.

I've implemented straightforward fix, but I think it would be better to revisit autobinding and make it more consistent with React behavior. For example, React doesn't autobind built-in methods, such as `render`, `setState`, `componentDidMount`, `componentWillUnmount`, etc.