### PR TITLE
`getInitialState` not being called on components created with createClass

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,8 +188,8 @@ function F(){}
 
 function createClass(obj) {
 	let cl = function(props, context) {
-		Component.call(this, props, context, BYPASS_HOOK);
 		extend(this, obj);
+		Component.call(this, props, context, BYPASS_HOOK);
 		bindAll(this);
 		newComponentHook.call(this, props, context);
 	};

--- a/test/index.js
+++ b/test/index.js
@@ -21,15 +21,18 @@ describe('preact-compat', () => {
 		});
 
 		it('should create a Component', () => {
+			let specState = { something: 1 };
 			let spec = {
 				foo: 'bar',
-				state: { something:1 },
+				getInitialState() {
+					return specState;
+				},
 				method: sinon.spy()
 			};
 			const C = createClass(spec);
 			let inst = new C();
 			expect(inst).to.have.property('foo', 'bar');
-			expect(inst).to.have.property('state', spec.state);
+			expect(inst).to.have.property('state', specState);
 			expect(inst).to.have.property('method').that.is.a('function');
 			expect(inst).to.be.an.instanceof(Component);
 			inst.method('a','b');


### PR DESCRIPTION
My colleagues and I ran into an issue with preact-compat where `getInitialState` wasn't being called for components created with `createClass`. What we found was that the `Component` function was being called prior to `getInitialState` being added to the actual object, so when the constructor tried to call that method it didn't exist. We switched the extend call in preact compat to come first to fix this issue.