### PR TITLE
Set Component.prototype.isReactComponent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -314,6 +314,8 @@ class Component extends PreactComponent {
 	}
 }
 
+Component.prototype.isReactComponent = {}
+
 
 
 export { DOM, PropTypes, Children, render, createClass, createFactory, createElement, cloneElement, isValidElement, findDOMNode, unmountComponentAtNode, Component };


### PR DESCRIPTION
React Hot Loader 3 uses React Proxy which relies on `isReactComponent` flag set on `React.Component` prototype.

See:
* gaearon/react-hot-loader version 3 `lib/patch.dev.js` (`require()`'s block)
* gaearon/react-proxy version 2 `src/createClassProxy.js` -> (`proxyClass` function)
* commit facebook/react@8364418 (2015-10-02) `src/isomorphic/modern/class/ReactComponent.js`