### PR TITLE
Correct jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "A React compatibility layer for Preact",
   "main": "dist/preact-compat.js",
   "minified:main": "dist/preact-compat.min.js",
-  "jsnext:main": "src/index.js",
+  "jsnext:main": "dist/preact-compat.es.js",
+  "module": "dist/preact-compat.es.js",
   "scripts": {
     "build": "npm-run-all transpile minify size",
     "transpile": "rollup -c rollup.config.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import fs from 'fs';
 import memory from 'rollup-plugin-memory';
 import babel from 'rollup-plugin-babel';
@@ -11,10 +10,7 @@ let external = Object.keys(pkg.peerDependencies || {}).concat(Object.keys(pkg.de
 
 export default {
 	entry: 'src/index.js',
-	dest: pkg.main,
-	sourceMap: path.resolve(pkg.main),
-	moduleName: pkg.amdName,
-	format: 'umd',
+	sourceMap: true,
 	exports: 'default',
 	useStrict: false,
 	external,
@@ -47,5 +43,9 @@ export default {
 			include: 'node_modules/**',
 			exclude: '**/*.css'
 		})
+	],
+	targets: [
+		{ dest: pkg.main, format: 'umd', moduleName: pkg.amdName },
+		{ dest: pkg.module, format: 'es' }
 	]
 };


### PR DESCRIPTION
According to jsforum/jsforum#5 `jsnext:main` should contain the transpiled version with the exception of ES6 modules.

Users can include the library without having to apply the babel transformations needed by this package
