### PR TITLE
Fix string refs in cloneElement()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,8 +195,11 @@ function statelessComponentHook(Ctor) {
 
 function createElement(...args) {
 	upgradeToVNodes(args, 2);
-	let vnode = h(...args);
+	return normalizeVNode(h(...args));
+}
 
+
+function normalizeVNode(vnode) {
 	applyClassName(vnode);
 
 	if (isStatelessComponent(vnode.nodeName)) {
@@ -221,7 +224,7 @@ function cloneElement(element, props, ...children) {
 		element.attributes || element.props,
 		element.children || element.props.children
 	);
-	return preactCloneElement(node, props, ...children);
+	return normalizeVNode(preactCloneElement(node, props, ...children));
 }
 
 

--- a/test/component.js
+++ b/test/component.js
@@ -256,5 +256,39 @@ describe('components', () => {
 			expect(ref2, 'ref2').to.have.have.been.calledTwice.and.calledWith(null);
 			expect(componentRef, 'componentRef').to.have.been.calledTwice.and.calledWith(null);
 		});
+
+		it('should support string refs via cloneElement()', () => {
+			let inner, outer;
+
+			const Inner = React.createClass({
+				render() {
+					inner = this;
+					return (
+						<div>
+							{React.cloneElement(React.Children.only(this.props.children), { id:'one' })}
+							{React.cloneElement(React.Children.only(this.props.children), { id:'two', ref:'two' })}
+						</div>
+					);
+				}
+			});
+
+			const Outer = React.createClass({
+				render() {
+					outer = this;
+					return (
+						<Inner>
+							<span ref="one">foo</span>
+						</Inner>
+					);
+				}
+			});
+
+			React.render(<Outer />, scratch);
+
+			let one = scratch.firstElementChild.children[0];
+			let two = scratch.firstElementChild.children[1];
+			expect(outer).to.have.property('refs').eql({ one });
+			expect(inner).to.have.property('refs').eql({ two });
+		});
 	});
 });


### PR DESCRIPTION
As discussed in developit/preact#280, `cloneElement()` was not patching String refs, which would then be passed into Preact unmodified, resulting in an exception.

/cc @robbiewxyz @aweber1