### PR TITLE
single out children before componentWillReceiveProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -371,7 +371,7 @@ function multihook() {
 
 function newComponentHook(props, context) {
 	propsHook.call(this, props, context);
-	this.componentWillReceiveProps = multihook(this.componentWillReceiveProps || 'componentWillReceiveProps', propsHook);
+	this.componentWillReceiveProps = multihook(propsHook, this.componentWillReceiveProps || 'componentWillReceiveProps');
 	this.render = multihook(beforeRender, this.render || 'render', afterRender);
 }
 

--- a/test/component.js
+++ b/test/component.js
@@ -63,6 +63,28 @@ describe('components', () => {
 		expect(foo).to.exist.and.have.deep.property('props.children').eql(children);
 	});
 
+	it('should single out children before componentWillReceiveProps', () => {
+		let props;
+
+		class Child extends React.Component {
+			componentWillReceiveProps(newProps) {
+				props = newProps;
+			}
+		}
+		class Parent extends React.Component {
+			render() {
+				return <Child>second</Child>;
+			}
+		}
+
+		let a = React.render(<Parent/>, scratch);
+		a.forceUpdate ();
+
+		expect(props).to.exist.and.deep.equal({
+			children: 'second'
+		});
+	});
+
 	describe('defaultProps', () => {
 		it('should support defaultProps for components', () => {
 			let render = sinon.stub().returns(<div />);

--- a/test/component.js
+++ b/test/component.js
@@ -78,7 +78,7 @@ describe('components', () => {
 		}
 
 		let a = React.render(<Parent/>, scratch);
-		a.forceUpdate ();
+		a.forceUpdate();
 
 		expect(props).to.exist.and.deep.equal({
 			children: 'second'


### PR DESCRIPTION
Components relying on React's `componentWillReceiveProps` expect `props.children` to pass single children without an array.  I've swapped the order of `propsHook` and `componentWillReceiveProps` on line #374 so that the behavior of our props processing will be more compatible with React.

I also wrote up a test for this behavior.