### PR TITLE
Make the Children API compatible with React

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,9 +182,7 @@ let Children = {
 		children.forEach(fn);
 	},
 	count(children) {
-		let count = 0;
-		Children.forEach(children, () => count++);
-		return count;
+		return children && children.length || 0;
 	},
 	only(children) {
 		children = Children.toArray(children);

--- a/src/index.js
+++ b/src/index.js
@@ -170,18 +170,21 @@ const ARR = [];
 // This API is completely unnecessary for Preact, so it's basically passthrough.
 let Children = {
 	map(children, fn, ctx) {
+		if (children == null) return null;
 		children = Children.toArray(children);
 		if (ctx && ctx!==children) fn = fn.bind(ctx);
 		return children.map(fn);
 	},
 	forEach(children, fn, ctx) {
+		if (children == null) return null;
 		children = Children.toArray(children);
 		if (ctx && ctx!==children) fn = fn.bind(ctx);
 		children.forEach(fn);
 	},
 	count(children) {
-		children = Children.toArray(children);
-		return children.length;
+		let count = 0;
+		Children.forEach(children, () => count++);
+		return count;
 	},
 	only(children) {
 		children = Children.toArray(children);


### PR DESCRIPTION
There were some differences to the following methods
that caused Preact to act differently than React:

- Children.map
- Children.forEach
- Children.count