### PR TITLE
Delete onChange attribute when aliased

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -333,6 +333,7 @@ function applyEventNormalization({ nodeName, attributes }) {
 			normalized = props[attr] || attr;
 		if (!attributes[normalized]) {
 			attributes[normalized] = multihook([attributes[props[attr]], attributes[props.onchange]]);
+			delete attributes[props.onchange];
 		}
 	}
 }


### PR DESCRIPTION
This should prevent the change event from firing twice when clicking on a checkbox, addressing this issue: https://github.com/developit/preact/issues/358