### PR TITLE
Add support for defaultValue to preact-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "npm-run-all lint build test:karma",
     "lint": "eslint {src,test}",
     "test:karma": "karma start --single-run",
-    "test:watch": "karma start --watch",
+    "test:watch": "karma start",
     "prepublish": "npm-run-all build test",
     "release": "npm run -s build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "npm-run-all lint build test:karma",
     "lint": "eslint {src,test}",
     "test:karma": "karma start --single-run",
+    "test:watch": "karma start --watch",
     "prepublish": "npm-run-all build test",
     "release": "npm run -s build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -82,14 +82,24 @@ options.vnode = vnode => {
 			}
 		}
 		else if (attrs) {
+			if (typeof vnode.nodeName==='string' && vnode.attributes && vnode.attributes.defaultValue) {
+				addDefaultValue(vnode);
+			}
 			handleElementVNode(vnode, attrs);
 		}
 	}
 	if (oldVnodeHook) oldVnodeHook(vnode);
 };
 
-
-
+function addDefaultValue(vnode) {
+	let attrs = vnode.attributes;
+	if (attrs && attrs.defaultValue) {
+		if (!attrs.value && attrs.value!==0) {
+			attrs.value = attrs.defaultValue;
+		}
+		delete attrs.defaultValue;
+	}
+}
 
 function handleComponentVNode(vnode) {
 	let tag = vnode.nodeName,

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ options.vnode = vnode => {
 			}
 		}
 		else if (attrs) {
-			if (typeof vnode.nodeName==='string' && vnode.attributes && vnode.attributes.defaultValue) {
+			if (typeof vnode.nodeName==='string' && attrs.defaultValue) {
 				if (!attrs.value && attrs.value!==0) {
 					attrs.value = attrs.defaultValue;
 				}

--- a/src/index.js
+++ b/src/index.js
@@ -83,23 +83,16 @@ options.vnode = vnode => {
 		}
 		else if (attrs) {
 			if (typeof vnode.nodeName==='string' && vnode.attributes && vnode.attributes.defaultValue) {
-				addDefaultValue(vnode);
+				if (!attrs.value && attrs.value!==0) {
+					attrs.value = attrs.defaultValue;
+				}
+				delete attrs.defaultValue;
 			}
 			handleElementVNode(vnode, attrs);
 		}
 	}
 	if (oldVnodeHook) oldVnodeHook(vnode);
 };
-
-function addDefaultValue(vnode) {
-	let attrs = vnode.attributes;
-	if (attrs && attrs.defaultValue) {
-		if (!attrs.value && attrs.value!==0) {
-			attrs.value = attrs.defaultValue;
-		}
-		delete attrs.defaultValue;
-	}
-}
 
 function handleComponentVNode(vnode) {
 	let tag = vnode.nodeName,

--- a/test/index.js
+++ b/test/index.js
@@ -59,6 +59,13 @@ describe('preact-compat', () => {
 			.that.equals('dynamic content');
 		});
 
+		it('should support defaultValue', () => {
+			let scratch = document.createElement('div');
+			(document.body || document.documentElement).appendChild(scratch);
+			render(<input defaultValue="foo"></input>, scratch);
+			expect(scratch.firstElementChild).to.have.property('value', 'foo');
+		});
+
 	});
 
 


### PR DESCRIPTION
Fixes https://github.com/developit/preact-compat/issues/261

This adds support for [this functionality](https://facebook.github.io/react/docs/uncontrolled-components.html#default-values) which I missed from the first time I tried out preact-compat. Somehow I forgot that it was missing until I went to release my app to some beta users today and realized it was kinda broken as it is haha.

I worked on this with @developit so hopefully it doesn't need much massaging to merge 👍 