### PR TITLE
Fix for the radio button not working with onChange

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ function applyEventNormalization({ nodeName, attributes }) {
 	}
 	if (props.onchange) {
 		nodeName = nodeName.toLowerCase();
-		let attr = nodeName==='input' && ['checkbox', 'radio'].indexOf(String(attributes.type).toLowerCase()) > -1 ? 'onclick' : 'oninput',
+		let attr = nodeName==='input' && attributes.type.match(/^che|rad/i) ? 'onclick' : 'oninput',
 			normalized = props[attr] || attr;
 		if (!attributes[normalized]) {
 			attributes[normalized] = multihook([attributes[props[attr]], attributes[props.onchange]]);

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ function applyEventNormalization({ nodeName, attributes }) {
 	}
 	if (props.onchange) {
 		nodeName = nodeName.toLowerCase();
-		let attr = nodeName==='input' && attributes.type.match(/^che|rad/i) ? 'onclick' : 'oninput',
+		let attr = nodeName==='input' && String(attributes.type).toLowerCase().match(/^che|rad/i) ? 'onclick' : 'oninput',
 			normalized = props[attr] || attr;
 		if (!attributes[normalized]) {
 			attributes[normalized] = multihook([attributes[props[attr]], attributes[props.onchange]]);

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ function applyEventNormalization({ nodeName, attributes }) {
 	}
 	if (props.onchange) {
 		nodeName = nodeName.toLowerCase();
-		let attr = nodeName==='input' && String(attributes.type).toLowerCase()==='checkbox' ? 'onclick' : 'oninput',
+		let attr = nodeName==='input' && ['checkbox', 'radio'].indexOf(String(attributes.type).toLowerCase()) > -1 ? 'onclick' : 'oninput',
 			normalized = props[attr] || attr;
 		if (!attributes[normalized]) {
 			attributes[normalized] = multihook([attributes[props[attr]], attributes[props.onchange]]);

--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ function applyEventNormalization({ nodeName, attributes }) {
 	}
 	if (props.onchange) {
 		nodeName = nodeName.toLowerCase();
-		let attr = nodeName==='input' && String(attributes.type).toLowerCase().match(/^che|rad/i) ? 'onclick' : 'oninput',
+		let attr = nodeName==='input' && /^che|rad/i.test(attributes.type) ? 'onclick' : 'oninput',
 			normalized = props[attr] || attr;
 		if (!attributes[normalized]) {
 			attributes[normalized] = multihook([attributes[props[attr]], attributes[props.onchange]]);


### PR DESCRIPTION
As suggested in the comment to the merged PR (ref: https://github.com/developit/preact-compat/pull/247) the event normalisation has broken the support for onChange on radio buttons. This is a potential fix