### PR TITLE
Expose the nativeEvent object to match React's Synthetic Event wrapper.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ let oldEventHook = options.event;
 options.event = e => {
 	e.persist = Object;
 	if (oldEventHook) e = oldEventHook(e);
+	e.nativeEvent = e;
 	return e;
 };
 


### PR DESCRIPTION
React's [SyntheticEvent](https://facebook.github.io/react/docs/events.html) wraps the native DOM event and expose it via a `nativeEvent` property.

In some instances you may wish to stop immediate propagation. In this case your code may look like this:

``` javascript
onClick = (e) => {
    e.stopPropagation();
    e.nativeEvent.stopImmediatePropagation();
};
```

Since Preact [doesn't use synthetic events](https://github.com/developit/preact/issues/36) we can safely call `stopImmediatePropagation` directly on the event object. This change allows React code to work without modification.