### PR TITLE
Add internal properties for enzyme test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /npm-debug.log
 .DS_Store
+.idea/

--- a/src/index.js
+++ b/src/index.js
@@ -538,16 +538,14 @@ function Component(props, context, opts) {
 	this.state = this.getInitialState ? this.getInitialState() : {};
 	this.refs = {};
 	this._refProxies = {};
-	this._reactInternalInstance = {};
 	if (opts!==BYPASS_HOOK) {
 		newComponentHook.call(this, props, context);
 	}
-	const component = this;
-	const componentDidMount = component.componentDidMount || 'componentDidMount';
-	this.componentDidMount = function () {
-		patch(component);
-		callMethod(this, componentDidMount, arguments);
-	};
+	Object.defineProperty(this, '_reactInternalInstance', {
+		get() {
+			return patch(this);
+		}
+	});
 }
 extend(Component.prototype = new PreactComponent(), {
 	constructor: Component,
@@ -573,12 +571,11 @@ extend(Component.prototype = new PreactComponent(), {
 });
 
 function patch(component) {
-	extend(component._reactInternalInstance, createReactCompositeComponent(component));
+	return createReactCompositeComponent(component);
 }
 
 function createReactCompositeComponent(component) {
 	const _currentElement = createReactElement(component);
-	const node = component.base;
 	let ret = {
 		_instance: component,
 		_currentElement,
@@ -621,7 +618,7 @@ function createReactDOMComponent(node) {
 			props: node[ATTR_KEY]
 		},
 		_renderedChildren: childNodes.map(child => {
-			if(child._component) {
+			if (child._component) {
 				return createReactCompositeComponent(child._component);
 			}
 			return createReactDOMComponent(child);

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ function renderSubtreeIntoContainer(parentComponent, vnode, container, callback)
 	let wrap = h(ContextProvider, { context: parentComponent.context }, vnode);
 	let c = render(wrap, container);
 	if (callback) callback(c);
-	return c;
+	return c._component || c.base;
 }
 
 

--- a/test/component.js
+++ b/test/component.js
@@ -508,4 +508,34 @@ describe('components', () => {
 			expect(spy).not.to.have.been.called;
 		});
 	});
+
+	describe('should support mock react internal property', () => {
+		class App extends React.Component {
+			render(){
+				return <AppInner/>;
+			}
+		}
+		class AppInner extends React.Component {
+			render(){
+				return <div>app inner</div>;
+			}
+		}
+		it('should support ReactDOMComponent', () => {
+			const appInner = React.render(<AppInner/>, scratch);
+			const appInnerReactInst = appInner._reactInternalInstance;
+			expect(appInnerReactInst).to.ok;
+			expect(appInnerReactInst._currentElement).to.ok;
+			expect(appInnerReactInst._currentElement.type).to.equal(AppInner);
+			expect(appInnerReactInst.getPublicInstance().base.tagName.toLowerCase()).to.equal('div');
+			expect(appInnerReactInst._renderedComponent).to.ok;
+			expect(appInnerReactInst._renderedComponent._currentElement.type).to.equal('div');
+		});
+
+		it('should suppport ReactCompositeComponent', () => {
+			const app = React.render(<App/>, scratch);
+			const appReactInst = app._reactInternalInstance;
+			expect(appReactInst).to.ok;
+			expect(appReactInst._renderedComponent._currentElement.type).to.equal(AppInner);
+		});
+	});
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import React, { render, createClass, createElement, cloneElement, Component, PropTypes } from '../src';
+import React, { render, createClass, createElement, cloneElement, Component, PropTypes, unstable_renderSubtreeIntoContainer } from '../src';
 
 describe('preact-compat', () => {
 	describe('render()', () => {
@@ -236,6 +236,35 @@ describe('preact-compat', () => {
 		it('should clone elements', () => {
 			let element = <foo a="b" c="d">a<span>b</span></foo>;
 			expect(cloneElement(element)).to.eql(element);
+		});
+	});
+
+	describe('unstable_renderSubtreeIntoContainer', () => {
+		it('should export instance', () => {
+			class Inner extends Component {
+				render() {
+					return null;
+				}
+				getNode() {
+					return 'inner';
+				}
+			}
+
+			class App extends Component {
+				render() {
+					return null;
+				}
+				componentDidMount() {
+					this.renderInner();
+				}
+				renderInner() {
+					const wrapper = document.createElement('div');
+					this.inner = unstable_renderSubtreeIntoContainer(this, <Inner/>, wrapper);
+				}
+			}
+			const root = document.createElement('div');
+			const app = render(<App/>, root);
+			expect(typeof app.inner.getNode === 'function').to.equal(true);
 		});
 	});
 });


### PR DESCRIPTION
I write a package called [`preact-test-utils`](https://github.com/windyGex/preact-test-utils). It only mock [some apis](https://github.com/airbnb/enzyme/blob/master/src/react-compat.js) that used in enzyme, I found enzyme access internal properties of react, but preact-compat have not these properties. So I want to push this code to preact-compat.
Now It can support `mount` mode test using enzyme. Maybe it can support `shallow` mode when your `preact-shallow-render` release.