### PR TITLE
Allow children in the props argument of cloneElement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -311,10 +311,10 @@ function cloneElement(element, props, ...children) {
 	// Arguments 3+ overwrite element.children in preactCloneElement
 	let cloneArgs = [node, props];
 	if (children && children.length) {
-		cloneArgs = cloneArgs.concat(children);
+		cloneArgs.push(children);
 	}
 	else if (props && props.children) {
-		cloneArgs = cloneArgs.concat(props.children);
+		cloneArgs.push(props.children);
 	}
 	return normalizeVNode(preactCloneElement(...cloneArgs));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,16 @@ function cloneElement(element, props, ...children) {
 		elementProps,
 		element.children || elementProps && elementProps.children
 	);
-	return normalizeVNode(preactCloneElement(node, props, ...children));
+	// Only provide the 3rd argument if needed.
+	// Arguments 3+ overwrite element.children in preactCloneElement
+	let cloneArgs = [node, props];
+	if (children && children.length) {
+		cloneArgs = cloneArgs.concat(children);
+	}
+	else if (props && props.children) {
+		cloneArgs = cloneArgs.concat(props.children);
+	}
+	return normalizeVNode(preactCloneElement(...cloneArgs));
 }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -237,6 +237,40 @@ describe('preact-compat', () => {
 			let element = <foo a="b" c="d">a<span>b</span></foo>;
 			expect(cloneElement(element)).to.eql(element);
 		});
+
+		it('should support props.children', () => {
+			let element = <foo children={<span>b</span>}></foo>;
+			expect(cloneElement(element)).to.eql(element);
+		});
+
+		it('children take precedence over props.children', () => {
+			let element = <foo children={<span>c</span>}><div>b</div></foo>;
+			let clone = cloneElement(element);
+			expect(clone).to.eql(element);
+			expect(clone.children[0].nodeName).to.eql('div');
+		});
+
+		it('should support children in prop argument', () => {
+			let element = <foo></foo>;
+			let children = [<span>b</span>];
+			let clone = cloneElement(element, { children });
+			expect(clone.children).to.eql(children);
+		});
+
+		it('children argument takes precedence over props.children', () => {
+			let element = <foo></foo>;
+			let childrenA = [<span>b</span>];
+			let childrenB = [<div>c</div>];
+			let clone = cloneElement(element, { children: childrenA }, ...childrenB);
+			expect(clone.children).to.eql(childrenB);
+		});
+
+		it('children argument takes precedence over props.children even if falsey', () => {
+			let element = <foo></foo>;
+			let childrenA = [<span>b</span>];
+			let clone = cloneElement(element, { children: childrenA }, undefined);
+			expect(clone.children).to.eql(undefined);
+		});
 	});
 
 	describe('unstable_renderSubtreeIntoContainer', () => {


### PR DESCRIPTION
cloneElement - if children are provided in the second
argument of cloneElement they are ignored.

`cloneElement(component, { children })` will now properly apply children to `component`

fixes #316 