### PR TITLE
React incompatibility: do not preserve children as an empty array

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -191,6 +191,13 @@ describe('preact-compat', () => {
 			expect(vnode.props.children[0].props).to.eql({ children:['t'] });
 		});
 
+		it('should not remove children if it’s an empty array', () => {
+			let vnode = createElement('div', {}, []);
+			expect(vnode).to.have.property('type', 'div');
+			expect(vnode).to.have.property('props').that.is.an('object');
+			expect(vnode.props.children).to.eql([]);
+		});
+
 		it('should normalize onChange', () => {
 			let props = { onChange(){} };
 


### PR DESCRIPTION
```js
const react = require('react')
react.createElement('div', {}, []).props.children
// -> []

const preact = require('preact-compat')
preact.createElement('div', {}, []).props.children
// -> undefined
```

Preact compat nulls children [here](https://github.com/developit/preact-compat/blob/c169d38224d5563b885420f27569507f8eb1f9e5/src/index.js#L81). 

I’ve added a test to show it but not sure what could be the proper fix for that 😕 