### PR TITLE
Fix Children.toArray when passed undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,8 @@ let Children = {
 		return children[0];
 	},
 	toArray(children) {
-		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children || []);
+		if (children == null) return [];
+		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
 	}
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,7 @@ let Children = {
 		return children[0];
 	},
 	toArray(children) {
-		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children);
+		return Array.isArray && Array.isArray(children) ? children : ARR.concat(children || []);
 	}
 };
 


### PR DESCRIPTION
There are cases when `this.props.chidren` is undefined and toArray was returning an array containing undefined instead of an empty array.