### PR TITLE
Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /npm-debug.log
 .DS_Store
+yarn.lock


### PR DESCRIPTION
This will prevent yarn users from accidentally committing their yarn.lock files to this project.