### PR TITLE
Replace proptypes package with official React prop-types package

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ render((
 
 ## Use Without Webpack/Browserify
 
-`preact-compat` and its single dependency [`proptypes`](https://git.io/proptypes) are both published as UMD modules as of `preact-compat` version `0.6`. This means you can use them via a `<script>` tag without issue:
+`preact-compat` and its single dependency [`proptypes`](https://github.com/reactjs/prop-types) are both published as UMD modules as of `preact-compat` version `0.6`. This means you can use them via a `<script>` tag without issue:
 
 ```html
 <script src="//unpkg.com/preact"></script>
@@ -168,7 +168,7 @@ You can see the above in action with this [JSFiddle Example](https://jsfiddle.ne
 
 ### PropTypes
 
-`preact-compat` adds support for validating PropTypes out of the box. This can be disabled the same way it is when using React, by defining a global `process.env.NODE_ENV='production'`.  PropType errors should work the same as in React - the [`proptypes`](https://git.io/proptypes) module used here is extracted verbatim from the React source into a standalone module.
+`preact-compat` adds support for validating PropTypes out of the box. This can be disabled the same way it is when using React, by defining a global `process.env.NODE_ENV='production'`.  PropType errors should work the same as in React - the [`proptypes`](https://github.com/reactjs/prop-types) module used here is extracted verbatim from the React source into a standalone module.
 
 <img src="http://i.imgur.com/tGT7Dvw.png" width="650" alt="PropType validation example output" />
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "immutability-helper": "^2.1.2",
     "preact-render-to-string": "^3.6.0",
     "preact-transition-group": "^1.1.0",
-    "proptypes": "^0.14.3",
+    "prop-types": "^15.5.3",
     "standalone-react-addons-pure-render-mixin": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "immutability-helper": "^2.1.2",
     "preact-render-to-string": "^3.6.0",
     "preact-transition-group": "^1.1.0",
-    "prop-types": "^15.5.3",
+    "prop-types": "^15.5.7",
     "standalone-react-addons-pure-render-mixin": "^0.1.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ export default {
 	useStrict: false,
 	globals: {
 		'preact': 'preact',
-		'proptypes': 'PropTypes'
+		'prop-types': 'PropTypes'
 	},
 	plugins: [
 		format==='umd' && memory({

--- a/src/index.js
+++ b/src/index.js
@@ -515,13 +515,8 @@ function propsHook(props, context) {
 		let ctor = typeof this==='function' ? this : this.constructor,
 			propTypes = this.propTypes || ctor.propTypes;
 		if (propTypes) {
-			for (let prop in propTypes) {
-				if (propTypes.hasOwnProperty(prop) && typeof propTypes[prop]==='function') {
-					const displayName = this.displayName || ctor.name;
-					let err = propTypes[prop](props, prop, displayName, 'prop');
-					if (err) console.error(new Error(err.message || err));
-				}
-			}
+			const displayName = this.displayName || ctor.name;
+			PropTypes.checkPropTypes(propTypes, props, 'prop', displayName);
 		}
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import PropTypes from 'proptypes';
+import PropTypes from 'prop-types';
 import { render as preactRender, cloneElement as preactCloneElement, h, Component as PreactComponent, options } from 'preact';
 
 const version = '15.1.0'; // trick libraries to think we are react

--- a/test/component.js
+++ b/test/component.js
@@ -178,7 +178,7 @@ describe('components', () => {
 
 			React.render(<Foo />, scratch);
 			expect(console.error).to.have.been.calledWithMatch({
-				message: 'Required prop `func` was not specified in `Foo`.'
+				message: 'The prop `func` is marked as required in `Foo`, but its value is `undefined`.'
 			});
 
 			console.error.reset();

--- a/test/component.js
+++ b/test/component.js
@@ -177,9 +177,7 @@ describe('components', () => {
 			sinon.stub(console, 'error');
 
 			React.render(<Foo />, scratch);
-			expect(console.error).to.have.been.calledWithMatch({
-				message: 'The prop `func` is marked as required in `Foo`, but its value is `undefined`.'
-			});
+			expect(console.error).to.have.been.calledWithMatch('Failed prop type: The prop `func` is marked as required in `Foo`, but its value is `undefined`.');
 
 			console.error.reset();
 
@@ -187,9 +185,7 @@ describe('components', () => {
 			expect(console.error).not.to.have.been.called;
 
 			React.render(<Foo func={()=>{}} bool="one" />, scratch);
-			expect(console.error).to.have.been.calledWithMatch({
-				message: 'Invalid prop `bool` of type `string` supplied to `Foo`, expected `boolean`.'
-			});
+			expect(console.error).to.have.been.calledWithMatch('Failed prop type: Invalid prop `bool` of type `string` supplied to `Foo`, expected `boolean`.');
 
 			console.error.restore();
 		}


### PR DESCRIPTION
Reactjs just recently released their own PropTypes package as per the documentation [here](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) and so I fiddled around and brought it into preact-compat!

Not sure if this is something you'd actually want seeing as:

- You have your own proptypes package that's working well enough
- PropTypes _are_ deprecated as of React v15.5

But I was fiddling around and all the tests pass so I figured why not submit as a PR? It's also one less thing to maintain. 

If you're open to it though, just let me know if I'm doing something horrible and I'll get this shaped right up :+1: 