### PR TITLE
bugfix: breaks react-router 3.0.4～3.0.5

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -544,7 +544,8 @@ function Component(props, context, opts) {
 		newComponentHook.call(this, props, context);
 	}
 }
-extend(Component.prototype = new PreactComponent(), {
+extend(Component.prototype, PreactComponent.prototype);
+extend(Component.prototype, {
 	constructor: Component,
 
 	isReactComponent: {},

--- a/src/index.js
+++ b/src/index.js
@@ -544,8 +544,7 @@ function Component(props, context, opts) {
 		newComponentHook.call(this, props, context);
 	}
 }
-extend(Component.prototype, PreactComponent.prototype);
-extend(Component.prototype, {
+extend(Component.prototype = PreactComponent.prototype, {
 	constructor: Component,
 
 	isReactComponent: {},

--- a/src/index.js
+++ b/src/index.js
@@ -544,7 +544,8 @@ function Component(props, context, opts) {
 		newComponentHook.call(this, props, context);
 	}
 }
-extend(Component.prototype = PreactComponent.prototype, {
+extend(Component.prototype, PreactComponent.prototype);
+extend(Component.prototype, {
 	constructor: Component,
 
 	isReactComponent: {},


### PR DESCRIPTION
throw an error, "Uncaught TypeError: _this.setState is not a function"
