### PR TITLE
bugfix: array[object] data children going to be an object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -500,7 +500,7 @@ function propsHook(props, context) {
 
 	// React annoyingly special-cases single children, and some react components are ridiculously strict about this.
 	let c = props.children;
-	if (c && Array.isArray(c) && c.length===1) {
+	if (c && Array.isArray(c) && c.length===1 && (typeof c[0] === 'string' || c[0] instanceof VNode)) {
 		props.children = c[0];
 
 		// but its totally still going to be an Array.

--- a/src/index.js
+++ b/src/index.js
@@ -500,7 +500,7 @@ function propsHook(props, context) {
 
 	// React annoyingly special-cases single children, and some react components are ridiculously strict about this.
 	let c = props.children;
-	if (c && Array.isArray(c) && c.length===1 && (typeof c[0] === 'string' || c[0] instanceof VNode)) {
+	if (c && Array.isArray(c) && c.length===1 && (typeof c[0]==='string' || typeof c[0]==='function' || c[0] instanceof VNode)) {
 		props.children = c[0];
 
 		// but its totally still going to be an Array.

--- a/test/component.js
+++ b/test/component.js
@@ -116,6 +116,22 @@ describe('components', () => {
 		});
 	});
 
+	it('should support array[object] children', () => {
+		let children;
+
+		class Foo extends React.Component {
+			render() {
+				children = this.props.children;
+				return <div />;
+			}
+		}
+
+		const data = [{a: ''}];
+		React.render(<Foo>{ data }</Foo>, scratch);
+
+		expect(children).to.exist.and.deep.equal(data);
+	});
+
 	describe('getInitialState', () => {
 		it('should be invoked for new components', () => {
 			class Foo extends React.Component {


### PR DESCRIPTION
the bug breaks antd-mobile picker component.

* https://github.com/ant-design/ant-design-mobile/blob/master/components/picker/index.tsx#L72
* https://github.com/react-component/m-picker/blob/master/src/MultiPicker.tsx#L20