### PR TITLE
Added a rollup config section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,43 @@ First, install it: `npm install --save-dev aliasify`
 }
 ```
 
+## Usage with Rollup
+
+Using `preact-compat` with rollup requires [rollup-plugin-alias](http://npm.im/rollup-plugin-alias), along with a few other plugins
+
+First, install it: `npm install --save-dev rollup-plugin-alias rollup-plugin-buble rollup-plugin-commonjs rollup-plugin-node-resolve rollup-plugin-replace`
+
+... then in your `rollup.config.js`, configure the alias plugin to point to `react` and `react-dom`, along with the rest of the plugins:
+
+```js
+import alias from "rollup-plugin-alias";
+import buble from "rollup-plugin-buble";
+import resolve from "rollup-plugin-node-resolve";
+import replace from "rollup-plugin-replace";
+import commonjs from "rollup-plugin-commonjs";
+// ...
+
+export default {
+    // ...
+    plugins: [
+        // ...
+        resolve({
+            jsnext: true // preact
+        }),
+        alias({
+            "react": "node_modules/preact-compat/dist/preact-compat.es.js",
+            "react-dom": "node_modules/preact-compat/dist/preact-compat.es.js",
+            "create-react-class": "node_modules/preact-compat/lib/create-react-class.js"
+        }),
+        commonjs(), // prop-types
+        replace({
+            "process.env.NODE_ENV": JSON.stringify("development") // prop-types
+        }),
+        buble() // es6
+    // ...
+}
+```
+
 ## Usage with Babel
 
 Using `preact-compat` with Babel is easy.


### PR DESCRIPTION
https://github.com/developit/preact-compat/issues/397

Probably needs to be trimmed down, included everything needed to run the example below the configs.

I also referenced the es file instead of the umd one. I figured if you're using rollup, you probably want to prefer es when available.

If it were to be trimmed down to match browserify and webpack, I guess it would only need the alias sections, but I don't know how obvious it would be to add the rest of the plugins to get the example running (which this does).