### PR TITLE
ReactJS compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,9 +164,10 @@ class ContextProvider {
 
 function renderSubtreeIntoContainer(parentComponent, vnode, container, callback) {
 	let wrap = h(ContextProvider, { context: parentComponent.context }, vnode);
-	let c = render(wrap, container);
-	if (callback) callback(c);
-	return c._component || c.base;
+	let renderContainer = render(wrap, container);
+	let component = renderContainer._component || renderContainer.base;
+	if (callback) callback.call(component, renderContainer);
+	return component;
 }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -274,16 +274,16 @@ describe('preact-compat', () => {
 	});
 
 	describe('unstable_renderSubtreeIntoContainer', () => {
-		it('should export instance', () => {
-			class Inner extends Component {
-				render() {
-					return null;
-				}
-				getNode() {
-					return 'inner';
-				}
+		class Inner extends Component {
+			render() {
+				return null;
 			}
+			getNode() {
+				return 'inner';
+			}
+		}
 
+		it('should export instance', () => {
 			class App extends Component {
 				render() {
 					return null;
@@ -294,6 +294,27 @@ describe('preact-compat', () => {
 				renderInner() {
 					const wrapper = document.createElement('div');
 					this.inner = unstable_renderSubtreeIntoContainer(this, <Inner/>, wrapper);
+				}
+			}
+			const root = document.createElement('div');
+			const app = render(<App/>, root);
+			expect(typeof app.inner.getNode === 'function').to.equal(true);
+		});
+
+		it('should there must be a context in callback', () => {
+			class App extends Component {
+				render() {
+					return null;
+				}
+				componentDidMount() {
+					this.renderInner();
+				}
+				renderInner() {
+					const wrapper = document.createElement('div');
+					const self = this;
+					unstable_renderSubtreeIntoContainer(this, <Inner/>, wrapper, function() {
+						self.inner = this;
+					});
 				}
 			}
 			const root = document.createElement('div');


### PR DESCRIPTION
Add context for callback function in "renderSubtreeIntoContainer" because behavior in the ReactJS