### PR TITLE
[WIP] implement children keys like react does

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -180,26 +180,95 @@ function unmountComponentAtNode(container) {
 	return false;
 }
 
+const KEY_SEPARATOR = '.';
+const KEY_SUBSEPARATOR = ':';
 
+function escape(key) {
+	let escapeRegex = /[=:]/g;
+	let escaperLookup = {
+		'=': '=0',
+		':': '=2'
+	};
+	let escapedString = ('' + key).replace(escapeRegex, (match) => {
+		return escaperLookup[match];
+	});
 
-const ARR = [];
+	return '$' + escapedString;
+}
 
-// This API is completely unnecessary for Preact, so it's basically passthrough.
+function getKey(component, i) {
+	console.log('getkey', i, component && component.key);
+	if (typeof component === 'object' && component != null && component.key) {
+		return escape(component.key);
+	}
+
+	return String(i);
+}
+
+function cloneAndReplaceKey(oldElement, newKey) {
+	return cloneElement(oldElement, {
+		key: newKey || oldElement.key
+	});
+}
+
+function iterateChildren(children, callback, name) {
+	let type = typeof children;
+  // null like
+	if (type === 'undefined' || type === 'boolean') {
+		children = null;
+	}
+
+  // single case
+	if (children === null || type === 'string' || type === 'number' || type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE) {
+		return callback(children, name === '' ? KEY_SEPARATOR + getKey(children, 0) : name);
+	}
+
+	let child;
+	let nextName;
+	let nextNamePrefix = name === '' ? KEY_SEPARATOR : name + KEY_SUBSEPARATOR;
+
+	if (Array.isArray(children)) {
+		console.log('array');
+		for (let i = 0; i < children.length; i++) {
+			child = children[i];
+			nextName = nextNamePrefix + getKey(child, i);
+			console.log('i', i, nextName);
+			iterateChildren(child, callback, nextName);
+		}
+	}
+	else if (type === 'object'){
+		throw new Error('can not iterate over object children');
+	}
+}
+
+let userProvidedKeyEscapeRegex = /\/+/g;
+function escapeUserProvidedKey(text) {
+	return ('' + text).replace(userProvidedKeyEscapeRegex, '$&/');
+}
+
+// This API is completely unnecessary for Preact,
+// but a lot of libraries rely on it to function properly.
 let Children = {
 	map(children, fn, ctx) {
-		if (children == null) return null;
-		children = Children.toArray(children);
-		if (ctx && ctx!==children) fn = fn.bind(ctx);
-		return children.map(fn);
+		let res = [];
+		if (children == null) {
+			return res;
+		}
+
+		mapChildrenWithKey(children, fn, res, '', 0,ctx);
+
+		return res;
 	},
 	forEach(children, fn, ctx) {
-		if (children == null) return null;
-		children = Children.toArray(children);
-		if (ctx && ctx!==children) fn = fn.bind(ctx);
-		children.forEach(fn);
+		if (children == null) {
+			return children;
+		}
+		mapChildrenWithKey(children, fn, [], '', 0, ctx);
 	},
 	count(children) {
-		return children && children.length || 0;
+		let count = 0;
+		Children.forEach(children, () => count++);
+		return count;
 	},
 	only(children) {
 		children = Children.toArray(children);
@@ -207,10 +276,42 @@ let Children = {
 		return children[0];
 	},
 	toArray(children) {
-		if (children == null) return [];
-		return ARR.concat(children);
+		let res = [];
+
+		mapChildrenWithKey(children, identity, res, '', 0, null);
+
+		return res;
 	}
 };
+
+function identity (el) {
+	return el;
+}
+
+function mapChildrenWithKey (children, fn, result, prefix, count, ctx) {
+	if (children == null) {
+		return children;
+	}
+
+	iterateChildren(children, (child, childKey) => {
+		let mappedChild = fn.call(ctx, child, count++);
+		if (Array.isArray(mappedChild)) {
+			mapChildrenWithKey(mappedChild, result, childKey, prefix, count, ctx);
+		}
+		else if (mappedChild) {
+			if (isValidElement(mappedChild)) {
+				console.log(prefix, mappedChild.key, child.key, childKey);
+				result.push(cloneAndReplaceKey(
+          child,
+          prefix + (mappedChild.key && (!child || child.key !== mappedChild.key) ? escapeUserProvidedKey(mappedChild.key) + '/' : '') + childKey
+        ));
+			}
+			else {
+				result.push(mappedChild);
+			}
+		}
+	}, prefix);
+}
 
 
 /** Track current render() component for ref assignment */
@@ -439,6 +540,7 @@ function collateMixins(mixins) {
 	return keyed;
 }
 
+const ARR = [];
 
 // apply a mapping of Arrays of mixin methods to a component prototype
 function applyMixins(proto, mixins) {

--- a/test/children.js
+++ b/test/children.js
@@ -1,0 +1,728 @@
+import React, { render, createClass, createElement, cloneElement, Component, PropTypes, unstable_renderSubtreeIntoContainer } from '../src';
+
+describe.only('Children', () => {
+	it('should support identity for simple', () => {
+		let context = {};
+		let callback = sinon.spy(function (kid, index) {
+			expect(this).to.eql(context);
+			return kid;
+		});
+
+		let simpleKid = <span key="simple" />;
+
+    // First pass children into a component to fully simulate what happens when
+    // using structures that arrive from transforms.
+
+		let instance = <div>{simpleKid}</div>;
+		React.Children.forEach(instance.props.children, callback, context);
+		expect(callback).to.have.been.calledWithExactly(simpleKid, 0);
+		callback.reset();
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		expect(callback).to.have.been.calledWithExactly(simpleKid, 0);
+		expect(mappedChildren[0]).to.eql(<span key=".$ismple" />);
+	});
+
+	it('should treat single arrayless child as being in array', () => {
+		let context = {};
+		let callback = sinon.spy(function(kid, index) {
+			expect(this).to.equal(context);
+			return kid;
+		});
+
+		let simpleKid = <span />;
+		let instance = <div>{simpleKid}</div>;
+		React.Children.forEach(instance.props.children, callback, context);
+		expect(callback).to.have.been.calledWithExactly(simpleKid, 0);
+		callback.reset();
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		expect(callback).to.have.been.calledWithExactly(simpleKid, 0);
+		expect(mappedChildren[0]).to.eql(<span key=".0" />);
+	});
+
+	it('should treat single child in array as expected', () => {
+		let context = {};
+		let callback = sinon.spy(function(kid, index) {
+			expect(this).to.equal(context);
+			return kid;
+		});
+
+		let simpleKid = <span key="simple" />;
+		let instance = <div>{[simpleKid]}</div>;
+		React.Children.forEach(instance.props.children, callback, context);
+		expect(callback).to.have.been.calledWithExactly(simpleKid);
+		callback.reset();
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		expect(callback).to.have.been.calledWithExactly(simpleKid);
+		expect(mappedChildren[0]).to.eql(<span key=".$simple" />);
+	});
+
+	it('should be called for each child', () => {
+		let zero = <div key="keyZero" />;
+		let one = null;
+		let two = <div key="keyTwo" />;
+		let three = null;
+		let four = <div key="keyFour" />;
+		let context = {};
+
+		let callback = sinon.spy(function(kid) {
+			expect(this).to.equal(context);
+			return kid;
+		});
+
+		let instance = (
+      <div>
+      {zero}
+      {one}
+      {two}
+      {three}
+      {four}
+      </div>
+    );
+
+		function assertCalls() {
+			expect(callback.args[0]).to.eql([zero, 0]);
+			expect(callback.args[1]).to.eql(['' /* one */, 1]);
+			expect(callback.args[2]).to.eql([two, 2]);
+			expect(callback.args[3]).to.eql(['' /* three */, 3]);
+			expect(callback.args[4]).to.eql([four, 4]);
+			callback.reset();
+		}
+
+		React.Children.forEach(instance.props.children, callback, context);
+		assertCalls();
+
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		assertCalls();
+		expect(mappedChildren).to.eql([
+			<div key=".$keyZero" />,
+			<div key=".$keyTwo" />,
+			<div key=".$keyFour" />
+		]);
+	});
+
+	it.only('should be called for each child in nested structure', () => {
+		let zero = <div key="keyZero" />;
+		let one = null;
+		let two = <div key="keyTwo" />;
+		let three = null;
+		let four = <div key="keyFour" />;
+		let five = <div key="keyFive" />;
+
+		let context = {};
+		let callback = sinon.spy((kid) => {
+			return kid;
+		});
+
+		let instance = (
+        <div>
+        {[[zero, one, two], [three, four], five]}
+      </div>
+    );
+
+		function assertCalls() {
+			expect(callback.callCount).to.equal(6);
+			expect(callback.args[0]).to.eql([zero, 0]);
+			expect(callback.args[1]).to.eql(['' /* one */, 1]);
+			expect(callback.args[2]).to.eql([two, 2]);
+			expect(callback.args[3]).to.eql(['' /* three */, 3]);
+			expect(callback.args[4]).to.eql([four, 4]);
+			expect(callback.args[5]).to.eql([five, 5]);
+			callback.reset();
+		}
+
+		React.Children.forEach(instance.props.children, callback, context);
+		assertCalls();
+
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		assertCalls();
+		expect(mappedChildren).to.eql([
+			<div key=".0:$keyZero" />,
+			<div key=".0:$keyTwo" />,
+			<div key=".1:$keyFour" />,
+			<div key=".$keyFive" />
+		]);
+	});
+
+	it('should retain key across two mappings', () => {
+		let zeroForceKey = <div key="keyZero" />;
+		let oneForceKey = <div key="keyOne" />;
+		let context = {};
+		let callback = sinon.spy(function(kid) {
+			expect(this).to.equal(context);
+			return kid;
+		});
+
+		let forcedKeys = (
+        <div>
+        {zeroForceKey}
+      {oneForceKey}
+      </div>
+    );
+
+		function assertCalls() {
+			expect(callback.args[0]).to.eql([zeroForceKey, 0]);
+			expect(callback.args[1]).to.eql([oneForceKey, 1]);
+			callback.reset();
+		}
+
+		React.Children.forEach(forcedKeys.props.children, callback, context);
+		assertCalls();
+
+		let mappedChildren = React.Children.map(
+      forcedKeys.props.children,
+      callback,
+      context,
+    );
+		assertCalls();
+		expect(mappedChildren).to.eql([
+			<div key=".$keyZero" />,
+			<div key=".$keyOne" />
+		]);
+	});
+
+	it('should be called for each child in an iterable without keys', () => {
+		let threeDivIterable = {
+			'@@iterator'() {
+				let i = 0;
+				return {
+					next() {
+						if (i++ < 3) {
+							return {value: <div />, done: false};
+						}
+						return {value: undefined, done: true};
+
+					}
+				};
+			}
+		};
+
+		let context = {};
+		let callback = sinon.spy(function(kid) {
+			expect(this).to.equal(context);
+			return kid;
+		});
+
+		let instance = (
+        <div>
+        {threeDivIterable}
+      </div>
+    );
+
+		function assertCalls() {
+			expect(callback.callCount).to.equal(3);
+			expect(callback.args[0]).to.eql([<div />, 0]);
+			expect(callback.args[1]).to.eql([<div />, 1]);
+			expect(callback.args[2]).to.eql([<div />, 2]);
+			callback.reset();
+		}
+
+		React.Children.forEach(instance.props.children, callback, context);
+		assertCalls();
+
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		assertCalls();
+		expect(mappedChildren).to.eql([
+			<div key=".0" />,
+			<div key=".1" />,
+			<div key=".2" />
+		]);
+	});
+
+	it('should be called for each child in an iterable with keys', () => {
+		let threeDivIterable = {
+			'@@iterator'() {
+				let i = 0;
+				return {
+					next() {
+						if (i++ < 3) {
+							return {value: <div key={'#' + i} />, done: false};
+						}
+						return {value: undefined, done: true};
+
+					}
+				};
+			}
+		};
+
+		let context = {};
+		let callback = sinon.spy(function(kid) {
+			expect(this).to.equal(context);
+			return kid;
+		});
+
+		let instance = (
+        <div>
+        {threeDivIterable}
+      </div>
+    );
+
+		function assertCalls() {
+			expect(callback.callCount).to.equal(3);
+			expect(callback.args[0]).to.eql([<div key="#1" />, 0]);
+			expect(callback.args[1]).to.eql([<div key="#2" />, 1]);
+			expect(callback.args[2]).to.eql([<div key="#3" />, 2]);
+			callback.reset();
+		}
+
+		React.Children.forEach(instance.props.children, callback, context);
+		assertCalls();
+
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		assertCalls();
+		expect(mappedChildren).to.eql([
+			<div key=".$#1" />,
+			<div key=".$#2" />,
+			<div key=".$#3" />
+		]);
+	});
+
+	it('should allow extension of native prototypes', () => {
+    /*eslint-disable no-extend-native */
+		String.prototype.key = 'react';
+		Number.prototype.key = 'rocks';
+    /*eslint-enable no-extend-native */
+
+		let instance = (
+        <div>
+        {'a'}
+      {13}
+      </div>
+    );
+
+		let context = {};
+		let callback = sinon.spy(function(kid) {
+			expect(this).to.equal(context);
+			return kid;
+		});
+
+		function assertCalls() {
+			expect(callback.callCount).to.equal(2, 0);
+			expect(callback.args[0]).to.eql(['a', 0]);
+			expect(callback.args[1]).to.eql([13, 1]);
+			callback.reset();
+		}
+
+		React.Children.forEach(instance.props.children, callback, context);
+		assertCalls();
+
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      context,
+    );
+		assertCalls();
+		expect(mappedChildren).to.eql(['a', 13]);
+
+		delete String.prototype.key;
+		delete Number.prototype.key;
+	});
+
+	it('should pass key to returned component', () => {
+		let mapFn = function(kid, index) {
+			return <div>{kid}</div>;
+		};
+
+		let simpleKid = <span key="simple" />;
+
+		let instance = <div>{simpleKid}</div>;
+		let mappedChildren = React.Children.map(instance.props.children, mapFn);
+
+		expect(React.Children.count(mappedChildren)).to.equal(1);
+		expect(mappedChildren[0]).not.to.equal(simpleKid);
+		expect(mappedChildren[0].props.children).to.equal(simpleKid);
+		expect(mappedChildren[0].key).to.equal('.$simple');
+	});
+
+	it('should invoke callback with the right context', () => {
+		let lastContext;
+		let callback = function(kid, index) {
+			lastContext = this;
+			return this;
+		};
+
+    // TODO: Use an object to test, after non-object fragments has fully landed.
+		let scopeTester = 'scope tester';
+
+		let simpleKid = <span key="simple" />;
+		let instance = <div>{simpleKid}</div>;
+		React.Children.forEach(instance.props.children, callback, scopeTester);
+		expect(lastContext).to.equal(scopeTester);
+
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      callback,
+      scopeTester,
+    );
+
+		expect(React.Children.count(mappedChildren)).to.equal(1);
+		expect(mappedChildren[0]).to.equal(scopeTester);
+	});
+
+	it('should be called for each child', () => {
+		let zero = <div key="keyZero" />;
+		let one = null;
+		let two = <div key="keyTwo" />;
+		let three = null;
+		let four = <div key="keyFour" />;
+
+		let mapped = [
+			<div key="giraffe" />, // Key should be joined to obj key
+			null, // Key should be added even if we don't supply it!
+			<div />, // Key should be added even if not supplied!
+			<span />, // Map from null to something.
+			<div key="keyFour" />
+		];
+		let callback = sinon.spy((kid, index) => {
+			return mapped[index];
+		});
+
+		let instance = (
+      <div>
+      {zero}
+      {one}
+      {two}
+      {three}
+      {four}
+      </div>
+    );
+
+		React.Children.forEach(instance.props.children, callback);
+		expect(callback.args[0]).to.eql([zero, 0]);
+		expect(callback.args[1]).to.eql(['' /* one */ , 1]); // null get converted to '' from preact
+		expect(callback.args[2]).to.eql([two, 2]);
+		expect(callback.args[3]).to.eql(['' /* three */, 3]);
+		expect(callback.args[4]).to.eql([four, 4]);
+		callback.reset();
+
+		let mappedChildren = React.Children.map(instance.props.children, callback);
+		expect(callback.callCount).to.equal(5);
+		expect(React.Children.count(mappedChildren)).to.equal(4);
+    // Keys default to indices.
+		expect([
+			mappedChildren[0].key,
+			mappedChildren[1].key,
+			mappedChildren[2].key,
+			mappedChildren[3].key
+		]).to.eql(['giraffe/.$keyZero', '.$keyTwo', '.3', '.$keyFour']);
+
+		expect(callback.args[0]).to.eql([zero, 0]);
+		expect(callback.args[1]).to.eql([one, 1]);
+		expect(callback.args[2]).to.eql([two, 2]);
+		expect(callback.args[3]).to.eql([three, 3]);
+		expect(callback.args[4]).to.eql([four, 4]);
+
+		expect(mappedChildren[0]).to.eql(<div key="giraffe/.$keyZero" />);
+		expect(mappedChildren[1]).to.eql(<div key=".$keyTwo" />);
+		expect(mappedChildren[2]).to.eql(<span key=".3" />);
+		expect(mappedChildren[3]).to.eql(<div key=".$keyFour" />);
+	});
+
+	it('should be called for each child in nested structure', () => {
+		let zero = <div key="keyZero" />;
+		let one = null;
+		let two = <div key="keyTwo" />;
+		let three = null;
+		let four = <div key="keyFour" />;
+		let five = <div key="keyFive" />;
+
+		let zeroMapped = <div key="giraffe" />; // Key should be overridden
+		let twoMapped = <div />; // Key should be added even if not supplied!
+		let fourMapped = <div key="keyFour" />;
+		let fiveMapped = <div />;
+
+		let callback = sinon.spy((kid) => {
+			switch (kid) {
+				case zero:
+					return zeroMapped;
+				case two:
+					return twoMapped;
+				case four:
+					return fourMapped;
+				case five:
+					return fiveMapped;
+				default:
+					return kid;
+			}
+		});
+
+		let frag = [[zero, one, two], [three, four], five];
+		let instance = <div>{[frag]}</div>;
+
+		React.Children.forEach(instance.props.children, callback);
+		expect(callback.callCount).to.equal(6);
+		expect(callback.args[0]).to.eql([zero, 0]);
+		expect(callback.args[1]).to.eql(['' /* one */, 1]);
+		expect(callback.args[2]).to.eql([two, 2]);
+		expect(callback.args[3]).to.eql(['' /* three */, 3]);
+		expect(callback.args[4]).to.eql([four, 4]);
+		expect(callback.args[5]).to.eql([five, 5]);
+		callback.reset();
+
+		let mappedChildren = React.Children.map(instance.props.children, callback);
+		expect(callback.callCount).to.equal(6);
+		expect(callback.args[0]).to.eql([zero, 0]);
+		expect(callback.args[1]).to.eql(['' /* one */, 1]);
+		expect(callback.args[2]).to.eql([two, 2]);
+		expect(callback.args[3]).to.eql(['' /* three */, 3]);
+		expect(callback.args[4]).to.eql([four, 4]);
+		expect(callback.args[5]).to.eql([five, 5]);
+
+		expect(React.Children.count(mappedChildren)).to.equal(4);
+    // Keys default to indices.
+		expect([
+			mappedChildren[0].key,
+			mappedChildren[1].key,
+			mappedChildren[2].key,
+			mappedChildren[3].key
+		]).to.eql([
+			'giraffe/.0:0:$keyZero',
+			'.0:0:$keyTwo',
+			'.0:1:$keyFour',
+			'.0:$keyFive'
+		]);
+
+		expect(mappedChildren[0]).to.eql(<div key="giraffe/.0:0:$keyZero" />);
+		expect(mappedChildren[1]).to.eql(<div key=".0:0:$keyTwo" />);
+		expect(mappedChildren[2]).to.eql(<div key=".0:1:$keyFour" />);
+		expect(mappedChildren[3]).to.eql(<div key=".0:$keyFive" />);
+	});
+
+	it('should retain key across two mappings', () => {
+		let zeroForceKey = <div key="keyZero" />;
+		let oneForceKey = <div key="keyOne" />;
+
+    // Key should be joined to object key
+		let zeroForceKeyMapped = <div key="giraffe" />;
+    // Key should be added even if we don't supply it!
+		let oneForceKeyMapped = <div />;
+
+		let mapFn = function(kid, index) {
+			return index === 0 ? zeroForceKeyMapped : oneForceKeyMapped;
+		};
+
+		let forcedKeys = (
+      <div>
+      {zeroForceKey}
+      {oneForceKey}
+      </div>
+    );
+
+		let expectedForcedKeys = ['giraffe/.$keyZero', '.$keyOne'];
+		let mappedChildrenForcedKeys = React.Children.map(
+      forcedKeys.props.children,
+      mapFn,
+    );
+		let mappedForcedKeys = mappedChildrenForcedKeys.map(c => c.key);
+		expect(mappedForcedKeys).to.eql(expectedForcedKeys);
+
+		let expectedRemappedForcedKeys = [
+			'giraffe/.$giraffe/.$keyZero',
+			'.$.$keyOne'
+		];
+		let remappedChildrenForcedKeys = React.Children.map(
+      mappedChildrenForcedKeys,
+      mapFn,
+    );
+		expect(remappedChildrenForcedKeys.map(c => c.key)).to.eql(
+      expectedRemappedForcedKeys,
+    );
+	});
+
+	it('should not throw if key provided is a dupe with array key', () => {
+		let zero = <div />;
+		let one = <div key="0" />;
+
+		let mapFn = function() {
+			return null;
+		};
+
+		let instance = (
+        <div>
+        {zero}
+      {one}
+      </div>
+    );
+
+		expect(() => {
+			React.Children.map(instance.props.children, mapFn);
+		}).not.to.throw();
+	});
+
+	it('should use the same key for a cloned element', () => {
+		let instance = (
+        <div>
+        <div />
+        </div>
+    );
+
+		let mapped = React.Children.map(
+      instance.props.children,
+      element => element,
+    );
+
+		let mappedWithClone = React.Children.map(
+      instance.props.children,
+      element => React.cloneElement(element)
+    );
+
+		expect(mapped[0].key).to.equal(mappedWithClone[0].key);
+	});
+
+	it('should use the same key for a cloned element with key', () => {
+		let instance = (
+        <div>
+        <div key="unique" />
+        </div>
+    );
+
+		let mapped = React.Children.map(
+      instance.props.children,
+      element => element
+    );
+
+		let mappedWithClone = React.Children.map(
+      instance.props.children, element => React.cloneElement(element, {key: 'unique'})
+    );
+
+		expect(mapped[0].key).to.equal(mappedWithClone[0].key);
+	});
+
+	it('should return 0 for null children', () => {
+		let numberOfChildren = React.Children.count(null);
+		expect(numberOfChildren).to.equal(0);
+	});
+
+	it('should return 0 for undefined children', () => {
+		let numberOfChildren = React.Children.count(undefined);
+		expect(numberOfChildren).to.equal(0);
+	});
+
+	it('should return 1 for single child', () => {
+		let simpleKid = <span key="simple" />;
+		let instance = <div>{simpleKid}</div>;
+		let numberOfChildren = React.Children.count(instance.props.children);
+		expect(numberOfChildren).to.equal(1);
+	});
+
+	it('should count the number of children in flat structure', () => {
+		let zero = <div key="keyZero" />;
+		let one = null;
+		let two = <div key="keyTwo" />;
+		let three = null;
+		let four = <div key="keyFour" />;
+
+		let instance = (
+      <div>
+      {zero}
+      {one}
+      {two}
+      {three}
+      {four}
+      </div>
+    );
+		let numberOfChildren = React.Children.count(instance.props.children);
+		expect(numberOfChildren).to.equal(5);
+	});
+
+	it('should count the number of children in nested structure', () => {
+		let zero = <div key="keyZero" />;
+		let one = null;
+		let two = <div key="keyTwo" />;
+		let three = null;
+		let four = <div key="keyFour" />;
+		let five = <div key="keyFive" />;
+
+		let instance = (
+        <div>
+        {[[[zero, one, two], [three, four], five], null]}
+      </div>
+    );
+		let numberOfChildren = React.Children.count(instance.props.children);
+		expect(numberOfChildren).to.equal(7);
+	});
+
+	it('should flatten children to an array', () => {
+		expect(React.Children.toArray(undefined)).to.eql([]);
+		expect(React.Children.toArray(null)).to.eql([]);
+
+		expect(React.Children.toArray(<div />).length).to.equal(1);
+		expect(React.Children.toArray([<div />]).length).to.equal(1);
+		expect(React.Children.toArray(<div />)[0].key).to.equal(
+      React.Children.toArray([<div />])[0].key,
+    );
+
+		let flattened = React.Children.toArray([
+      [<div key="apple" />, <div key="banana" />, <div key="camel" />],
+      [<div key="banana" />, <div key="camel" />, <div key="deli" />]
+		]);
+		console.log('flattened', flattened.map((k) => k.key));
+		expect(flattened.length).to.equal(6);
+		expect(flattened[1].key).to.contain('banana');
+		expect(flattened[3].key).to.contain('banana');
+		expect(flattened[1].key).not.to.equal(flattened[3].key);
+
+		let reversed = React.Children.toArray([
+      [<div key="camel" />, <div key="banana" />, <div key="apple" />],
+      [<div key="deli" />, <div key="camel" />, <div key="banana" />]
+		]);
+		expect(flattened[0].key).to.equal(reversed[2].key);
+		expect(flattened[1].key).to.equal(reversed[1].key);
+		expect(flattened[2].key).to.equal(reversed[0].key);
+		expect(flattened[3].key).to.equal(reversed[5].key);
+		expect(flattened[4].key).to.equal(reversed[4].key);
+		expect(flattened[5].key).to.equal(reversed[3].key);
+
+    // null/undefined/bool are all omitted
+		expect(React.Children.toArray([1, 'two', null, undefined, true])).to.eql([
+			1,
+			'two'
+		]);
+	});
+
+	it('should escape keys', () => {
+		let zero = <div key="1" />;
+		let one = <div key="1=::=2" />;
+		let instance = (
+      <div>
+      {zero}
+      {one}
+      </div>
+    );
+		let mappedChildren = React.Children.map(
+      instance.props.children,
+      kid => kid,
+    );
+		expect(mappedChildren).to.eql([
+			<div key=".$1" />,
+			<div key=".$1=0=2=2=02" />
+		]);
+	});
+});

--- a/test/index.js
+++ b/test/index.js
@@ -54,9 +54,9 @@ describe('preact-compat', () => {
 
 			render(<div>dynamic content</div>, root);
 			expect(root)
-			.to.have.property('textContent')
-			.that.is.a('string')
-			.that.equals('dynamic content');
+			  .to.have.property('textContent')
+			  .that.is.a('string')
+			  .that.equals('dynamic content');
 		});
 
 		it('should support defaultValue', () => {
@@ -155,7 +155,7 @@ describe('preact-compat', () => {
 			expect(def.mixins[1].bar).to.have.been.calledOnce.and.calledAfter(def.mixins[0].bar);
 
 			let props = {},
-				state = {};
+				  state = {};
 			inst.componentWillMount(props, state);
 			expect(def.mixins[1].componentWillMount)
 				.to.have.been.calledOnce
@@ -180,7 +180,7 @@ describe('preact-compat', () => {
 		it('should normalize vnodes', () => {
 			let vnode = <div a="b"><a>t</a></div>;
 			// using typeof Symbol here injects a polyfill, which ruins the test. we'll hardcode the non-symbol value for now.
-			let $$typeof = 0xeac7;
+			  let $$typeof = 0xeac7;
 			expect(vnode).to.have.property('$$typeof', $$typeof);
 			expect(vnode).to.have.property('type', 'div');
 			expect(vnode).to.have.property('props').that.is.an('object');


### PR DESCRIPTION
Still work in progress, this comes from issues I was having around libraries assuming how the children methods behave. 

I ported all tests from https://github.com/facebook/react/blob/master/src/isomorphic/children/__tests__/ReactChildren-test.js that were relevant. 

Things left to do

- [ ] Make all tests pass, currently 8 failing
- [ ] Cleanup code and simplify as much as possible
