### PR TITLE
Delete children instead of keeping an undefined key inside the props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ options.vnode = vnode => {
 
 		if (typeof tag==='function') {
 			if (tag[COMPONENT_WRAPPER_KEY]===true || (tag.prototype && 'isReactComponent' in tag.prototype)) {
-				if (vnode.children && String(vnode.children)==='') vnode.children = undefined;
+				if (vnode.children && String(vnode.children)==='') delete vnode.children;
 				if (vnode.children) attrs.children = vnode.children;
 
 				if (!vnode.preactCompatNormalized) {
@@ -86,7 +86,7 @@ options.vnode = vnode => {
 			}
 		}
 		else {
-			if (vnode.children && String(vnode.children)==='') vnode.children = undefined;
+			if (vnode.children && String(vnode.children)==='') delete vnode.children;
 			if (vnode.children) attrs.children = vnode.children;
 
 			if (attrs.defaultValue) {


### PR DESCRIPTION
React does not define an `undefined` value for children inside props, if none are passed.

Faced the problem, when I had to deal with the paypal checkout system, which iterates over the props, and verifies that only supported props are passed. 

So paypal checkout just checks if invalid props are passed, and in this case `Object.keys(props)` does contain `children: undefined`. ugh. 

Btw. This is the only bug, I faced so far with `preact` and `preact-compat`thanks for this small and and beautiful library
