### PR TITLE
props.className as an alias of props.class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -368,6 +368,7 @@ function applyClassName(vnode) {
 
 let classNameDescriptor = {
 	configurable: true,
+	enumerable: false,
 	get() { return this.class; },
 	set(v) { this.class = v; }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -358,12 +358,18 @@ function applyEventNormalization({ nodeName, attributes }) {
 }
 
 
-function applyClassName({ attributes }) {
-	if (!attributes) return;
-	let cl = attributes.className || attributes.class;
-	if (cl) attributes.className = cl;
+function applyClassName(vnode) {
+	let a = vnode.attributes || (vnode.attributes = {});
+	if (a.className) a.class = a.className;
+	Object.defineProperty(a, 'className', classNameDescriptor);
 }
 
+
+let classNameDescriptor = {
+	configurable: true,
+	get() { return this.class; },
+	set(v) { this.class = v; }
+};
 
 function extend(base, props) {
 	for (let key in props) {

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -14,6 +14,6 @@ describe('jsx', () => {
 
 		let html = renderToString(jsx);
 
-		expect(html).to.equal('<div class="foo bar" data-foo="bar"><span id="some_id">inner!</span>ab</div>');
+		expect(html).to.equal('<div data-foo="bar" class="foo bar"><span id="some_id">inner!</span>ab</div>');
 	});
 });


### PR DESCRIPTION
Instead of trying to normalize, which breaks preact-compat-nested non-compat components, let's install `props.className` as an alias pointing to `props.class`.