### PR TITLE
IE11 seems to define Symbol but without the method 'for'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const ELEMENTS = 'a abbr address area article aside audio b base bdi bdo big blo
 
 const REACT_ELEMENT_TYPE = (typeof Symbol!=='undefined' && Symbol.for && Symbol.for('react.element')) || 0xeac7;
 
-const COMPONENT_WRAPPER_KEY = typeof Symbol!=='undefined' ? Symbol.for('__preactCompatWrapper') : '__preactCompatWrapper';
+const COMPONENT_WRAPPER_KEY = (typeof Symbol!=='undefined' && Symbol.for) ? Symbol.for('__preactCompatWrapper') : '__preactCompatWrapper';
 
 // don't autobind these methods since they already have guaranteed context.
 const AUTOBIND_BLACKLIST = {


### PR DESCRIPTION
Fixes: 
"Object does not support the method for" error in IE11. 