### PR TITLE
[BUG FIX] Normalize VNode when nodeName is string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,6 +96,9 @@ options.vnode = vnode => {
 				delete attrs.defaultValue;
 			}
 
+			if (!vnode.preactCompatNormalized) {
+				normalizeVNode(vnode);
+			}
 			handleElementVNode(vnode, attrs);
 		}
 	}


### PR DESCRIPTION
#### Example
```jsx
<input ref="input" {...otherProps} />
```
#### Current Behavior
Throw an error in preact.esm.js (220): 'value is not a function'.
```js
function setAccessor(node, name, old, value, isSvg) {
	if (name === 'className') name = 'class';

	if (name === 'key') {
		// ignore
	} else if (name === 'ref') {
		if (old) old(null);
		if (value) value(node); // ERROR OCCURRED!
	}
        // ...
}
```
#### Expected Behavior
No error.