### PR TITLE
Add `react-dom-factories` usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ All you have to do is add an alias for `react` and `react-dom`:
             'react': 'preact-compat',
             'react-dom': 'preact-compat',
             // Not necessary unless you consume a module using `createClass`
-            'create-react-class': 'preact-compat/lib/create-react-class'
+            'create-react-class': 'preact-compat/lib/create-react-class',
+            // Not necessary unless you consume a module requiring `react-dom-factories`
+            'react-dom-factories': 'preact-compat/lib/react-dom-factories'
         }
     }
     // ...
@@ -87,7 +89,9 @@ First, install it: `npm install --save-dev aliasify`
             "react": "preact-compat",
             "react-dom": "preact-compat",
             // Not necessary unless you consume a module using `createClass`
-            "create-react-class": "preact-compat/lib/create-react-class"
+            "create-react-class": "preact-compat/lib/create-react-class",
+            // Not necessary unless you consume a module requiring `react-dom-factories`
+            "react-dom-factories": "preact-compat/lib/react-dom-factories"
         }
     }
     // ...
@@ -112,7 +116,9 @@ All you have to do is tell babel to process jsx with 'h' and add an alias for `r
             "react": "preact-compat",
             "react-dom": "preact-compat",
             // Not necessary unless you consume a module using `createClass`
-            "create-react-class": "preact-compat/lib/create-react-class"
+            "create-react-class": "preact-compat/lib/create-react-class",
+            // Not necessary unless you consume a module requiring `react-dom-factories`
+            "react-dom-factories" "preact-compat/lib/react-dom-factories"
         }
         }]
     ],


### PR DESCRIPTION
Upgrading packages for a project, I got tripped up by `react-dom-factories` in ag-grid. After taking some time to work out quite what was going on I found the PR for the support, but no documentation on it - so this should help out others in the same situation as me.