### PR TITLE
findDOMNode should return element if given element (fixes #493)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "phantomjs-prebuilt": "^2.1.10",
     "preact": "^8.1.0",
     "preact-jsx-chai": "^2.2.1",
+    "preact-render-to-string": "=3.7.2",
     "pretty-bytes-cli": "^2.0.0",
     "rollup": "^0.55.5",
     "rollup-plugin-babel": "^3.0.3",
@@ -82,7 +83,6 @@
   },
   "dependencies": {
     "immutability-helper": "^2.1.2",
-    "preact-render-to-string": "^3.7.2",
     "preact-transition-group": "^1.1.0",
     "prop-types": "^15.5.8",
     "standalone-react-addons-pure-render-mixin": "^0.1.1"

--- a/src/index.js
+++ b/src/index.js
@@ -403,7 +403,7 @@ function shallowDiffers(a, b) {
 
 
 function findDOMNode(component) {
-	return component && component.base || null;
+	return component && (component.base || component.nodeType === 1 && component) || null;
 }
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -301,6 +301,15 @@ describe('preact-compat', () => {
 			expect(findDOMNode(helper)).to.be.instanceof(Node);
 		});
 
+		it('should return null if given null', () => {
+			expect(findDOMNode(null)).to.be.null;
+		}),
+
+		it('should return a regular DOM Element if given a regular DOM Element', () => {
+			let scratch = document.createElement('div');
+			expect(findDOMNode(scratch)).to.equal(scratch);
+		}),
+
 		// NOTE: React.render() returning false or null has the component pointing
 		// 			to no DOM Node, in contrast, Preact always render an empty Text DOM Node.
 		xit('should return null if render returns false', () => {


### PR DESCRIPTION
Also had to lock `preact-render-to-string` at 3.7.2 as 3.8.0 is a breaking change.  See https://github.com/developit/preact-render-to-string/issues/59