### PR TITLE
Fix DEV always being false in webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,11 @@ const CAMEL_PROPS = /^(?:accent|alignment|arabic|baseline|cap|clip|color|fill|fl
 const BYPASS_HOOK = {};
 
 /*global process*/
-const DEV = typeof process !== 'undefined' && process.env && process.env.NODE_ENV!=='production';
+let DEV = false;
+try {
+	DEV = process.env.NODE_ENV!=='production';
+}
+catch (e) {}
 
 // a component that renders nothing. Used to replace components for unmountComponentAtNode.
 function EmptyComponent() { return null; }


### PR DESCRIPTION
Found this while debugging why `prop-types` didn't work in `preact-cli` (see: https://github.com/developit/preact-cli/issues/627).

Turns out the reason is that our global `DEV` variable was always set to `false` when `preact-compat` was bundled. The reason being that we checked if `process` is available:

```js
const DEV = typeof process !== 'undefined' && process.env && process.env.NODE_ENV!=='production';
```

But bundlers typically don't shim the `process` object and instead replace all string occurrences of `process.env.NODE_ENV` with `development` for example. After the bundler has done its magic the code would now look like this:

```js
const DEV = typeof process !== 'undefined' && process.env && 'development'!=='production';
```

Note that `process` is still `undefined` which is why `DEV` will always be false.

