### PR TITLE
Use node 10 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 4
+  - 10


### PR DESCRIPTION
This PR runs tests via node 10 instead of the long unsupported version 4.