### PR TITLE
Disable preact-compat with preact 10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webpack": "^1.15.0"
   },
   "peerDependencies": {
-    "preact": ">=5"
+    "preact": "<10"
   },
   "dependencies": {
     "immutability-helper": "^2.7.1",


### PR DESCRIPTION
This helps usher folks to `preact/compat`, and avoids serious issues that arise when (accidentally) including `preact-compat` with preact 10+, including [`Object.prototype` pollution](https://github.com/cssinjs/jss/pull/1091#issuecomment-484502359).